### PR TITLE
Fixed babel-preset-env browser targets

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,13 +1,9 @@
+const BABEL_ENV = process.env.BABEL_ENV;
+const targets = BABEL_ENV === 'test' ? { node: 6 } : { browsers: 'defaults' };
+
 module.exports = {
 	presets: [
-		[
-			'@babel/preset-env',
-			{
-				targets: {
-					node: 6,
-				},
-			},
-		],
+		['@babel/preset-env', { targets } ],
 		'@babel/preset-react',
 	],
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"build:commonjs": "mkdir -p lib && babel ./src -d lib",
 		"build:umd": "webpack --output-filename=react-gettext.js",
 		"build:umd:min": "NODE_ENV=production webpack --output-filename=react-gettext.min.js",
-		"test": "jest",
+		"test": "BABEL_ENV=test jest",
 		"prepublish": "npm run build"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## What?
The current babel build is being outputted with `target: node 6` which introduces regressions for some browsers.

The current build outputs `node` execution context which breaks some browsers (note the usage of `const`, `class`, etc) eg `withGettext.js`:
<img width="952" alt="Screen Shot 2019-11-21 at 2 35 05 PM" src="https://user-images.githubusercontent.com/6025510/69374756-6349be80-0c6c-11ea-87c9-c9e72c906b30.png">


## Why?
This command `"build:commonjs": "mkdir -p lib && babel ./src -d lib"` does not go through webpack, hence the `babel.config.js` file is used, which uses `node: 6` target

## Fix
Introduces a way for this config to change the target based on the current execution environment

## Testing done
- Ran `npm test`
- Verified outputted files are now pure ES5 (example below `withGettext.js` - no more usage of `const`, `class`, etc)
<img width="1477" alt="Screen Shot 2019-11-21 at 2 35 25 PM" src="https://user-images.githubusercontent.com/6025510/69374775-6f358080-0c6c-11ea-92aa-d9fb41e7411d.png">

Ping @eugene-manuilov for comments 😄 